### PR TITLE
Disable Metadata

### DIFF
--- a/helpers/comfyui.py
+++ b/helpers/comfyui.py
@@ -44,7 +44,7 @@ class ComfyUI:
         print("Server running")
 
     def run_server(self, output_directory, input_directory):
-        command = f"python ./ComfyUI/main.py --output-directory {output_directory} --input-directory {input_directory}"
+        command = f"python ./ComfyUI/main.py --output-directory {output_directory} --input-directory {input_directory} --disable-metadata"
         server_process = subprocess.Popen(command, shell=True)
         server_process.wait()
 


### PR DESCRIPTION
Disable metadata embedding on generated images.

This will allow users to protect their workflows.