### PR TITLE
Add impact pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The following custom nodes are also supported, these are fixed to specific commi
 - [ComfyUI PhotoMaker](https://github.com/shiimizu/ComfyUI-PhotoMaker/tree/75542a4)
 - [ComfyUI IPAdapter Plus](https://github.com/cubiq/ComfyUI_IPAdapter_plus/tree/4e898fe)
 - [ComfyUI Controlnet Aux](https://github.com/Fannovel16/comfyui_controlnet_aux/tree/6d6f63c)
+- [ComfyUI Impact Pack](https://github.com/ltdrdata/ComfyUI-Impact-Pack/tree/6aee0aa)
 - [ComfyUI Inspire Pack](https://github.com/ltdrdata/ComfyUI-Inspire-Pack/tree/c8231dd)
 - [ComfyUI Logic](https://github.com/theUpsider/ComfyUI-Logic/tree/fb88973)
 - [ComfyUI AnimateDiff Evolved](https://github.com/Kosinkadink/ComfyUI-AnimateDiff-Evolved/tree/d2bf367)

--- a/cog.yaml
+++ b/cog.yaml
@@ -32,6 +32,10 @@ build:
     - insightface
     - onnx
 
+    # ComfyUI-Impact-Pack
+    - segment-anything
+    - piexif
+
     # comfyui_controlnet_aux
     # https://github.com/Fannovel16/comfyui_controlnet_aux/blob/main/requirements.txt
     - importlib_metadata

--- a/cog.yaml
+++ b/cog.yaml
@@ -36,6 +36,9 @@ build:
     - segment-anything
     - piexif
 
+    # ComfyUI-Impact-Subpack
+    - ultralytics!=8.0.177
+
     # comfyui_controlnet_aux
     # https://github.com/Fannovel16/comfyui_controlnet_aux/blob/main/requirements.txt
     - importlib_metadata

--- a/helpers/ComfyUI_Impact_Pack.py
+++ b/helpers/ComfyUI_Impact_Pack.py
@@ -1,0 +1,11 @@
+class ComfyUI_Impact_Pack:
+    @staticmethod
+    def add_weights(weights_to_download, node):
+        if "class_type" in node and node["class_type"] in [
+            "UltralyticsDetectorProvider",
+        ]:
+            weights_to_download.extend([
+                "bbox/hand_yolov8s.pt",
+                "bbox/face_yolov8m.pt",
+                "segm/person_yolov8m-seg.pt"
+            ])

--- a/helpers/comfyui.py
+++ b/helpers/comfyui.py
@@ -18,6 +18,7 @@ from helpers.ComfyUI_IPAdapter_plus import ComfyUI_IPAdapter_plus
 from helpers.ComfyUI_Controlnet_Aux import ComfyUI_Controlnet_Aux
 from helpers.ComfyUI_Reactor_Node import ComfyUI_Reactor_Node
 from helpers.ComfyUI_InstantID import ComfyUI_InstantID
+from helpers.ComfyUI_Impact_Pack import ComfyUI_Impact_Pack
 
 
 class ComfyUI:
@@ -82,6 +83,7 @@ class ComfyUI:
                 ComfyUI_Reactor_Node,
                 ComfyUI_IPAdapter_plus,
                 ComfyUI_InstantID,
+                ComfyUI_Impact_Pack,
             ]:
                 handler.add_weights(weights_to_download, node)
 

--- a/scripts/clone_plugins.sh
+++ b/scripts/clone_plugins.sh
@@ -9,7 +9,7 @@
 repos=(
   "https://github.com/cubiq/ComfyUI_IPAdapter_plus 4e898fe"
   "https://github.com/Fannovel16/comfyui_controlnet_aux 6d6f63c"
-  "https://github.com/ltdrdata/ComfyUI-Impact-Pack 6aee0aa"
+  "https://github.com/fofr/ComfyUI-Impact-Pack cc29d62"
   "https://github.com/ltdrdata/ComfyUI-Inspire-Pack c8231dd"
   "https://github.com/theUpsider/ComfyUI-Logic fb88973"
   "https://github.com/Kosinkadink/ComfyUI-AnimateDiff-Evolved d2bf367"

--- a/scripts/clone_plugins.sh
+++ b/scripts/clone_plugins.sh
@@ -9,6 +9,7 @@
 repos=(
   "https://github.com/cubiq/ComfyUI_IPAdapter_plus 4e898fe"
   "https://github.com/Fannovel16/comfyui_controlnet_aux 6d6f63c"
+  "https://github.com/ltdrdata/ComfyUI-Impact-Pack 6aee0aa"
   "https://github.com/ltdrdata/ComfyUI-Inspire-Pack c8231dd"
   "https://github.com/theUpsider/ComfyUI-Logic fb88973"
   "https://github.com/Kosinkadink/ComfyUI-AnimateDiff-Evolved d2bf367"

--- a/weights.json
+++ b/weights.json
@@ -314,5 +314,10 @@
   ],
   "SAMS": [
     "sam_vit_b_01ec64.pth"
+  ],
+  "ULTRALYTICS": [
+    "bbox/hand_yolov8s.pt",
+    "bbox/face_yolov8m.pt",
+    "segm/person_yolov8m-seg.pt"
   ]
 }

--- a/weights.json
+++ b/weights.json
@@ -308,5 +308,11 @@
     "GFPGANv1.3.pth",
     "GFPGANv1.4.pth",
     "RestoreFormer.pth"
+  ],
+  "MMDETS": [
+    "bbox/mmdet_anime-face_yolov3.pth"
+  ],
+  "SAMS": [
+    "sam_vit_b_01ec64.pth"
   ]
 }


### PR DESCRIPTION
Follow up to #20 

- Uses a forked version of Impact Pack (see https://github.com/fofr/ComfyUI-Impact-Pack):
  - prevents any automatic installation
  - loads the impact_subpack as a submodule
  - includes a default config
  - prevents automatic deletion of the impact_subpack directory if .git is missing
- Adds SAM and Ultralytics weights
- Automatically downloads Ultralytics weights if a UltralyticsDetectorBox node is used