### PR TITLE
Add Rembg, refactor custom node helpers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@
 *.gif
 *.mp4
 *.zip
+*.tar
 *.webp
 *.webm
 
@@ -23,6 +24,7 @@
 
 # Files
 scripts/*
+test/*
 updated_weights.json
 
 # Extension files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2024-05-02
+
+Adding support for [rembg](https://github.com/danielgatis/rembg), used in a variety of custom nodes
+
+Update ComfyUI_tinyterraNodes to latest, but [fork to remove inefficient rembg nodes](https://github.com/fofr/ComfyUI_tinyterraNodes/tree/without-rembg)
+
 ## 2024-05-01
 
 Update [ComfyUI Controlnet Aux](https://github.com/Fannovel16/comfyui_controlnet_aux/tree/692a3d0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
-## 2024-05-02
+## 2024-05-03
 
-Adding support for [rembg](https://github.com/danielgatis/rembg), used in a variety of custom nodes
-
-Update ComfyUI_tinyterraNodes to latest, but [fork to remove inefficient rembg nodes](https://github.com/fofr/ComfyUI_tinyterraNodes/tree/without-rembg)
+- Adding support for [rembg](https://github.com/danielgatis/rembg), used in a variety of custom nodes
+- Update ComfyUI_tinyterraNodes to latest to fix rembg issue
 
 ## 2024-05-01
 

--- a/cog.yaml
+++ b/cog.yaml
@@ -37,8 +37,7 @@ build:
     - matplotlib
     - pilgram
     - scikit-learn
-    # RemBG causes Tiny_TerraNodes to take >40s to start
-    # - rembg
+    - rembg
 
     # ComfyUI_essentials
     - numba

--- a/comfyui.py
+++ b/comfyui.py
@@ -10,6 +10,7 @@ import websocket
 import random
 import requests
 import custom_node_helpers as helpers
+from node import Node
 from weights_downloader import WeightsDownloader
 from urllib.error import URLError
 
@@ -76,19 +77,18 @@ class ComfyUI:
         weights_filetypes = self.weights_downloader.supported_filetypes
 
         for node in workflow.values():
-            self.apply_helper_methods("add_weights", weights_to_download, node)
+            self.apply_helper_methods("add_weights", weights_to_download, Node(node))
 
-            if "inputs" in node:
-                for input in node["inputs"].values():
-                    if isinstance(input, str):
-                        if any(key in input for key in embedding_to_fullname):
-                            weights_to_download.extend(
-                                embedding_to_fullname[key]
-                                for key in embedding_to_fullname
-                                if key in input
-                            )
-                        elif any(input.endswith(ft) for ft in weights_filetypes):
-                            weights_to_download.append(input)
+            for input in node["inputs"].values():
+                if isinstance(input, str):
+                    if any(key in input for key in embedding_to_fullname):
+                        weights_to_download.extend(
+                            embedding_to_fullname[key]
+                            for key in embedding_to_fullname
+                            if key in input
+                        )
+                    elif any(input.endswith(ft) for ft in weights_filetypes):
+                        weights_to_download.append(input)
 
         weights_to_download = list(set(weights_to_download))
 
@@ -106,7 +106,7 @@ class ComfyUI:
 
     def handle_known_unsupported_nodes(self, workflow):
         for node in workflow.values():
-            self.apply_helper_methods("check_for_unsupported_nodes", node)
+            self.apply_helper_methods("check_for_unsupported_nodes", Node(node))
 
     def handle_inputs(self, workflow):
         print("Checking inputs")

--- a/custom_node_helpers/ComfyUI_BRIA_AI_RMBG.py
+++ b/custom_node_helpers/ComfyUI_BRIA_AI_RMBG.py
@@ -1,5 +1,4 @@
 from custom_node_helper import CustomNodeHelper
-from node import Node
 
 MODELS = [
     "RMBG-1.4/model.pth",
@@ -12,7 +11,7 @@ class ComfyUI_BRIA_AI_RMBG(CustomNodeHelper):
 
     @staticmethod
     def add_weights(weights_to_download, node):
-        if Node.is_type(node, "BRIA_RMBG_ModelLoader_Zho"):
+        if node.is_type("BRIA_RMBG_ModelLoader_Zho"):
             weights_to_download.extend(MODELS)
 
     @staticmethod

--- a/custom_node_helpers/ComfyUI_BRIA_AI_RMBG.py
+++ b/custom_node_helpers/ComfyUI_BRIA_AI_RMBG.py
@@ -1,4 +1,5 @@
 from custom_node_helper import CustomNodeHelper
+from node import Node
 
 MODELS = [
     "RMBG-1.4/model.pth",
@@ -11,9 +12,7 @@ class ComfyUI_BRIA_AI_RMBG(CustomNodeHelper):
 
     @staticmethod
     def add_weights(weights_to_download, node):
-        if "class_type" in node and node["class_type"] in [
-            "BRIA_RMBG_ModelLoader_Zho",
-        ]:
+        if Node.is_type(node, "BRIA_RMBG_ModelLoader_Zho"):
             weights_to_download.extend(MODELS)
 
     @staticmethod

--- a/custom_node_helpers/ComfyUI_Controlnet_Aux.py
+++ b/custom_node_helpers/ComfyUI_Controlnet_Aux.py
@@ -1,5 +1,4 @@
 from custom_node_helper import CustomNodeHelper
-from node import Node
 
 MODELS = {
     "UNet.pth": "bdsqlsz/qinglong_controlnet-lllite/Annotators",
@@ -133,18 +132,17 @@ class ComfyUI_Controlnet_Aux(CustomNodeHelper):
 
     @staticmethod
     def add_weights(weights_to_download, node):
-        node_class = node.get("class_type")
         node_mapping = ComfyUI_Controlnet_Aux.node_class_mapping()
 
-        if Node.is_type_in(node, node_mapping.keys()):
-            class_weights = node_mapping[node_class]
+        if node.is_type_in(node_mapping.keys()):
+            class_weights = node_mapping[node.type()]
             weights_to_download.extend(
                 class_weights if isinstance(class_weights, list) else [class_weights]
             )
 
         # Additional check for AIO_Preprocessor and its preprocessor input value
-        if Node.is_type(node, "AIO_Preprocessor"):
-            preprocessor = Node.value(node, "preprocessor")
+        if node.is_type("AIO_Preprocessor"):
+            preprocessor = node.value("preprocessor")
             if preprocessor in node_mapping:
                 preprocessor_weights = node_mapping[preprocessor]
                 weights_to_download.extend(

--- a/custom_node_helpers/ComfyUI_Controlnet_Aux.py
+++ b/custom_node_helpers/ComfyUI_Controlnet_Aux.py
@@ -1,4 +1,5 @@
 from custom_node_helper import CustomNodeHelper
+from node import Node
 
 MODELS = {
     "UNet.pth": "bdsqlsz/qinglong_controlnet-lllite/Annotators",
@@ -135,17 +136,15 @@ class ComfyUI_Controlnet_Aux(CustomNodeHelper):
         node_class = node.get("class_type")
         node_mapping = ComfyUI_Controlnet_Aux.node_class_mapping()
 
-        if node_class and node_class in node_mapping:
+        if Node.is_type_in(node, node_mapping.keys()):
             class_weights = node_mapping[node_class]
             weights_to_download.extend(
                 class_weights if isinstance(class_weights, list) else [class_weights]
             )
 
         # Additional check for AIO_Preprocessor and its preprocessor input value
-        if node_class == "AIO_Preprocessor" and "preprocessor" in node.get(
-            "inputs", {}
-        ):
-            preprocessor = node["inputs"]["preprocessor"]
+        if Node.is_type(node, "AIO_Preprocessor"):
+            preprocessor = Node.value(node, "preprocessor")
             if preprocessor in node_mapping:
                 preprocessor_weights = node_mapping[preprocessor]
                 weights_to_download.extend(

--- a/custom_node_helpers/ComfyUI_Frame_Interpolation.py
+++ b/custom_node_helpers/ComfyUI_Frame_Interpolation.py
@@ -59,17 +59,12 @@ class ComfyUI_Frame_Interpolation(CustomNodeHelper):
     @staticmethod
     def check_for_unsupported_nodes(node):
         unsupported_nodes = {
-            "IFRNet VFI": "IFRNet weights are not available",
-            "IFUnet VFI": "IFUnet weights are not available",
-            "MCM VFI": "MCM is not available because cupy is not installed",
-            "GMFSS Fortuna VFI": "GMFSS Fortuna VFI is not available because cupy is not installed",
-            "Sepconv VFI": "Sepconv VFI is not available because cupy is not installed",
-            "STMFNet VFI": "STMFNet VFI is not available because cupy is not installed",
-            "FLAVR VFI": "FLAVR VFI weights are not available",
+            "IFRNet VFI": "Use RIFE or FILM - IFRNet weights are not available",
+            "IFUnet VFI": "Use RIFE or FILM - IFUnet weights are not available",
+            "MCM VFI": "Use RIFE or FILM - MCM is not available because cupy is not installed",
+            "GMFSS Fortuna VFI": "Use RIFE or FILM - GMFSS Fortuna VFI is not available because cupy is not installed",
+            "Sepconv VFI": "Use RIFE or FILM - Sepconv VFI is not available because cupy is not installed",
+            "STMFNet VFI": "Use RIFE or FILM - STMFNet VFI is not available because cupy is not installed",
+            "FLAVR VFI": "Use RIFE or FILM - FLAVR VFI weights are not available",
         }
-        node_class = node.get("class_type")
-        if node_class in unsupported_nodes:
-            reason = unsupported_nodes[node_class]
-            raise ValueError(
-                f"{node_class} node is not supported: Use RIFE or FILM - {reason}"
-            )
+        node.raise_if_unsupported(unsupported_nodes)

--- a/custom_node_helpers/ComfyUI_IPAdapter_plus.py
+++ b/custom_node_helpers/ComfyUI_IPAdapter_plus.py
@@ -138,18 +138,18 @@ class ComfyUI_IPAdapter_plus(CustomNodeHelper):
 
     @staticmethod
     def add_weights(weights_to_download, node):
-        if "class_type" in node and node["class_type"] in [
-            "IPAdapterUnifiedLoader",
-            "IPAdapterUnifiedLoaderFaceID",
-            "IPAdapterUnifiedLoaderCommunity",
-        ]:
-            preset = node["inputs"]["preset"]
+        if node.is_type_in(
+            [
+                "IPAdapterUnifiedLoader",
+                "IPAdapterUnifiedLoaderFaceID",
+                "IPAdapterUnifiedLoaderCommunity",
+            ]
+        ):
+            preset = node.input("preset")
             print(f"Including weights for IPAdapter preset: {preset}")
             if preset:
                 weights_to_download.extend(
                     ComfyUI_IPAdapter_plus.get_preset_weights(preset)
                 )
-        elif "class_type" in node and node["class_type"] in [
-            "IPAdapterInsightFaceLoader",
-        ]:
+        elif node.is_type("IPAdapterInsightFaceLoader"):
             weights_to_download.append("models/buffalo_l")

--- a/custom_node_helpers/ComfyUI_Impact_Pack.py
+++ b/custom_node_helpers/ComfyUI_Impact_Pack.py
@@ -3,9 +3,7 @@ from custom_node_helper import CustomNodeHelper
 class ComfyUI_Impact_Pack(CustomNodeHelper):
     @staticmethod
     def add_weights(weights_to_download, node):
-        if "class_type" in node and node["class_type"] in [
-            "UltralyticsDetectorProvider",
-        ]:
+        if node.is_type("UltralyticsDetectorProvider"):
             weights_to_download.extend([
                 "bbox/hand_yolov8s.pt",
                 "bbox/face_yolov8m.pt",

--- a/custom_node_helpers/ComfyUI_InstantID.py
+++ b/custom_node_helpers/ComfyUI_InstantID.py
@@ -1,23 +1,24 @@
 from custom_node_helper import CustomNodeHelper
 
+
 class ComfyUI_InstantID(CustomNodeHelper):
     @staticmethod
     def add_weights(weights_to_download, node):
-        if "class_type" in node:
-            if node["class_type"] == "InstantIDFaceAnalysis":
-                weights_to_download.append("models/antelopev2")
-            elif node["class_type"] == "InstantIDModelLoader":
-                if "inputs" in node and "instantid_file" in node["inputs"]:
-                    if node["inputs"]["instantid_file"] == "ipadapter.bin":
-                        node["inputs"]["instantid_file"] = "instantid-ip-adapter.bin"
-                        weights_to_download.append("instantid-ip-adapter.bin")
-            elif node["class_type"] == "ControlNetLoader":
-                if "inputs" in node and "control_net_name" in node["inputs"]:
-                    if (
-                        node["inputs"]["control_net_name"]
-                        == "instantid/diffusion_pytorch_model.safetensors"
-                    ):
-                        node["inputs"][
-                            "control_net_name"
-                        ] = "instantid-controlnet.safetensors"
-                        weights_to_download.append("instantid-controlnet.safetensors")
+        if node.is_type("InstantIDFaceAnalysis"):
+            weights_to_download.append("models/antelopev2")
+        elif (
+            node.is_type("InstantIDModelLoader")
+            and node.input("instantid_file") == "ipadapter.bin"
+        ):
+            node.set_input("instantid_file", "instantid-ip-adapter.bin")
+            weights_to_download.append("instantid-ip-adapter.bin")
+        elif node.is_type("ControlNetLoader"):
+            if node.has_key("control_net_name"):
+                if (
+                    node.input("control_net_name")
+                    == "instantid/diffusion_pytorch_model.safetensors"
+                ):
+                    node.set_input(
+                        "control_net_name", "instantid-controlnet.safetensors"
+                    )
+                    weights_to_download.append("instantid-controlnet.safetensors")

--- a/custom_node_helpers/ComfyUI_InstantID.py
+++ b/custom_node_helpers/ComfyUI_InstantID.py
@@ -13,12 +13,9 @@ class ComfyUI_InstantID(CustomNodeHelper):
             node.set_input("instantid_file", "instantid-ip-adapter.bin")
             weights_to_download.append("instantid-ip-adapter.bin")
         elif node.is_type("ControlNetLoader"):
-            if node.has_key("control_net_name"):
-                if (
-                    node.input("control_net_name")
-                    == "instantid/diffusion_pytorch_model.safetensors"
-                ):
-                    node.set_input(
-                        "control_net_name", "instantid-controlnet.safetensors"
-                    )
-                    weights_to_download.append("instantid-controlnet.safetensors")
+            if (
+                node.input("control_net_name")
+                == "instantid/diffusion_pytorch_model.safetensors"
+            ):
+                node.set_input("control_net_name", "instantid-controlnet.safetensors")
+                weights_to_download.append("instantid-controlnet.safetensors")

--- a/custom_node_helpers/ComfyUI_KJNodes.py
+++ b/custom_node_helpers/ComfyUI_KJNodes.py
@@ -3,7 +3,7 @@ from custom_node_helper import CustomNodeHelper
 class ComfyUI_KJNodes(CustomNodeHelper):
     @staticmethod
     def add_weights(weights_to_download, node):
-        if node.get("class_type") == "BatchCLIPSeg":
+        if node.is_type("BatchCLIPSeg"):
             weights_to_download.extend(["models--CIDAS--clipseg-rd64-refined"])
 
     @staticmethod
@@ -12,7 +12,4 @@ class ComfyUI_KJNodes(CustomNodeHelper):
             "StabilityAPI_SD3": "Calling an external API and passing your key is not supported and is unsafe",
             "Superprompt": "Superprompt is not supported as it needs to download T5 weights",
         }
-        node_class = node.get("class_type")
-        if node_class in unsupported_nodes:
-            reason = unsupported_nodes[node_class]
-            raise ValueError(f"{node_class} node is not supported: {reason}")
+        node.raise_if_unsupported(unsupported_nodes)

--- a/custom_node_helpers/ComfyUI_LayerDiffuse.py
+++ b/custom_node_helpers/ComfyUI_LayerDiffuse.py
@@ -1,5 +1,6 @@
 from custom_node_helper import CustomNodeHelper
 
+
 class ComfyUI_LayerDiffuse(CustomNodeHelper):
     @staticmethod
     def get_config_weights(config):
@@ -34,23 +35,27 @@ class ComfyUI_LayerDiffuse(CustomNodeHelper):
 
     @staticmethod
     def add_weights(weights_to_download, node):
-        if "class_type" in node and node["class_type"] in [
-            "LayeredDiffusionApply",
-            "LayeredDiffusionJointApply",
-            "LayeredDiffusionCondApply",
-            "LayeredDiffusionCondJointApply",
-        ]:
-            config = node["inputs"]["config"]
+        if node.is_type_in(
+            [
+                "LayeredDiffusionApply",
+                "LayeredDiffusionJointApply",
+                "LayeredDiffusionCondApply",
+                "LayeredDiffusionCondJointApply",
+            ]
+        ):
+            config = node.input("config")
             weights_to_download.extend(ComfyUI_LayerDiffuse.get_config_weights(config))
-        elif "class_type" in node and node["class_type"] in [
+        elif node.is_type(
             "LayeredDiffusionDiffApply",
-        ]:
-            config = f"Diff, {node['inputs']['config']}"
+        ):
+            config = f"Diff, {node.input('config')}"
             weights_to_download.extend(ComfyUI_LayerDiffuse.get_config_weights(config))
-        elif "class_type" in node and node["class_type"] in [
-            "LayeredDiffusionDecode",
-            "LayeredDiffusionDecodeRGBA",
-            "LayeredDiffusionDecodeSplit",
-        ]:
-            sd_version = node["inputs"]["sd_version"]
+        elif node.is_type_in(
+            [
+                "LayeredDiffusionDecode",
+                "LayeredDiffusionDecodeRGBA",
+                "LayeredDiffusionDecodeSplit",
+            ]
+        ):
+            sd_version = node.input("sd_version")
             weights_to_download.extend(ComfyUI_LayerDiffuse.get_vae_weights(sd_version))

--- a/custom_node_helpers/ComfyUI_Reactor_Node.py
+++ b/custom_node_helpers/ComfyUI_Reactor_Node.py
@@ -1,5 +1,6 @@
 from custom_node_helper import CustomNodeHelper
 
+
 class ComfyUI_Reactor_Node(CustomNodeHelper):
     facedetection_weights = {
         "retinaface_resnet50": "detection_Resnet50_Final.pth",
@@ -10,16 +11,18 @@ class ComfyUI_Reactor_Node(CustomNodeHelper):
 
     @staticmethod
     def add_weights(weights_to_download, node):
-        if "class_type" in node and node["class_type"] in [
-            "ReActorFaceSwap",
-            "ReActorLoadFaceModel",
-            "ReActorSaveFaceModel",
-        ]:
+        if node.is_type_in(
+            [
+                "ReActorFaceSwap",
+                "ReActorLoadFaceModel",
+                "ReActorSaveFaceModel",
+            ]
+        ):
             weights_to_download.append("models/buffalo_l")
             weights_to_download.append("parsing_parsenet.pth")
 
-            if "facedetection" in node["inputs"]:
-                facedetection_model = node["inputs"]["facedetection"]
+            if node.has_input("facedetection"):
+                facedetection_model = node.input("facedetection")
                 if facedetection_model in ComfyUI_Reactor_Node.facedetection_weights:
                     weights_to_download.append(
                         ComfyUI_Reactor_Node.facedetection_weights[facedetection_model]

--- a/custom_node_helpers/ComfyUI_Segment_Anything.py
+++ b/custom_node_helpers/ComfyUI_Segment_Anything.py
@@ -16,12 +16,14 @@ MODEL_WEIGHTS = {
 class ComfyUI_Segment_Anything(CustomNodeHelper):
     @staticmethod
     def add_weights(weights_to_download, node):
-        if "class_type" in node and node["class_type"] in [
-            "SAMModelLoader (segment anything)",
-            "GroundingDinoModelLoader (segment anything)",
-        ]:
-            model_name = node["inputs"].get("model_name")
-            if model_name and model_name in MODEL_WEIGHTS:
+        if node.is_type_in(
+            [
+                "SAMModelLoader (segment anything)",
+                "GroundingDinoModelLoader (segment anything)",
+            ]
+        ):
+            model_name = node.input("model_name")
+            if model_name in MODEL_WEIGHTS:
                 weights_to_download.append(MODEL_WEIGHTS[model_name])
 
                 if "GroundingDINO" in model_name:

--- a/custom_node_helpers/ComfyUI_tinyterraNodes.py
+++ b/custom_node_helpers/ComfyUI_tinyterraNodes.py
@@ -1,0 +1,10 @@
+from custom_node_helper import CustomNodeHelper
+
+
+class ComfyUI_tinyterraNodes(CustomNodeHelper):
+    @staticmethod
+    def check_for_unsupported_nodes(node):
+        if node.get("class_type") == "imageREMBG":
+            raise ValueError(
+                "imageREMBG node is not supported in tinyterraNodes. Recommend using RemBGSession from ComfyUI_Essentials"
+            )

--- a/custom_node_helpers/ComfyUI_tinyterraNodes.py
+++ b/custom_node_helpers/ComfyUI_tinyterraNodes.py
@@ -4,7 +4,7 @@ from custom_node_helper import CustomNodeHelper
 class ComfyUI_tinyterraNodes(CustomNodeHelper):
     @staticmethod
     def check_for_unsupported_nodes(node):
-        if node.is_type("imageREMBG"):
+        if node.is_type("ttN imageREMBG"):
             raise ValueError(
                 "imageREMBG node is not supported in tinyterraNodes. Recommend using RemBGSession from ComfyUI_Essentials"
             )

--- a/custom_node_helpers/ComfyUI_tinyterraNodes.py
+++ b/custom_node_helpers/ComfyUI_tinyterraNodes.py
@@ -4,7 +4,7 @@ from custom_node_helper import CustomNodeHelper
 class ComfyUI_tinyterraNodes(CustomNodeHelper):
     @staticmethod
     def check_for_unsupported_nodes(node):
-        if node.get("class_type") == "imageREMBG":
+        if node.is_type("imageREMBG"):
             raise ValueError(
                 "imageREMBG node is not supported in tinyterraNodes. Recommend using RemBGSession from ComfyUI_Essentials"
             )

--- a/custom_node_helpers/WAS_Node_Suite.py
+++ b/custom_node_helpers/WAS_Node_Suite.py
@@ -24,7 +24,6 @@ class WAS_Node_Suite(CustomNodeHelper):
             "Text Random Prompt": "Makes an HTTP request out to Lexica, which is unsupported",
             "True Random.org Number Generator": "Needs an API key which cannot be supplied",
             "Image Seamless Texture": "img2texture dependency has not been added",
-            "Image Rembg (Remove Background)": "rembg dependency has not been added because it causes custom nodes to fail",
             "MiDaS Model Loader": "WAS MiDaS nodes are not currently supported",
             "MiDaS Mask Image": "WAS MiDaS nodes are not currently supported",
             "MiDaS Depth Approximation": "WAS MiDaS nodes are not currently supported",

--- a/custom_node_helpers/WAS_Node_Suite.py
+++ b/custom_node_helpers/WAS_Node_Suite.py
@@ -1,13 +1,12 @@
 from custom_node_helper import CustomNodeHelper
 
+
 class WAS_Node_Suite(CustomNodeHelper):
     @staticmethod
     def add_weights(weights_to_download, node):
-        node_class = node.get("class_type")
-        model_name = node.get("inputs", {}).get("model")
         if (
-            node_class == "CLIPSeg Model Loader"
-            and model_name == "CIDAS/clipseg-rd64-refined"
+            node.is_type("CLIPSeg Model Loader")
+            and node.input("model") == "CIDAS/clipseg-rd64-refined"
         ):
             weights_to_download.extend(["models--CIDAS--clipseg-rd64-refined"])
 
@@ -29,7 +28,4 @@ class WAS_Node_Suite(CustomNodeHelper):
             "MiDaS Depth Approximation": "WAS MiDaS nodes are not currently supported",
             "Text File History Loader": "History is not persisted",
         }
-        node_class = node.get("class_type")
-        if node_class in unsupported_nodes:
-            reason = unsupported_nodes[node_class]
-            raise ValueError(f"{node_class} node is not supported: {reason}")
+        node.raise_if_unsupported(unsupported_nodes)

--- a/custom_node_helpers/rembg.py
+++ b/custom_node_helpers/rembg.py
@@ -19,8 +19,8 @@ class rembg(CustomNodeHelper):
     @staticmethod
     def add_weights(weights_to_download, node):
         # RemBGSession+ is in ComfyUI_essentials
-        if Node.is_type(node, "RemBGSession+"):
-            model = Node.value(node, "model")
+        if node.is_type("RemBGSession+"):
+            model = node.input("model")
             model_weights = {
                 "u2net: general purpose": ["u2net.onnx"],
                 "u2netp: lightweight general purpose": ["u2netp.onnx"],
@@ -38,8 +38,8 @@ class rembg(CustomNodeHelper):
                 weights_to_download.extend(model_weights[model])
 
         # Image Rembg (Remove Background) is in WAS nodes
-        elif Node.is_type(node, "Image Rembg (Remove Background)"):
-            model = Node.value(node, "model")
+        elif node.is_type("Image Rembg (Remove Background)"):
+            model = node.input("model")
             if model == "sam":
                 weights_to_download.extend(
                     [

--- a/custom_node_helpers/rembg.py
+++ b/custom_node_helpers/rembg.py
@@ -1,19 +1,6 @@
 from custom_node_helper import CustomNodeHelper
-from node import Node
 
 BASE_PATH = "/root/.u2net/"
-MODELS = [
-    "isnet-anime.onnx",
-    "isnet-general-use.onnx",
-    "silueta.onnx",
-    "u2net.onnx",
-    "u2net_cloth_seg.onnx",
-    "u2net_human_seg.onnx",
-    "u2netp.onnx",
-    "vit_b-decoder-quant.onnx",
-    "vit_b-encoder-quant.onnx",
-]
-
 
 class rembg(CustomNodeHelper):
     @staticmethod
@@ -25,7 +12,7 @@ class rembg(CustomNodeHelper):
                 "u2net: general purpose": ["u2net.onnx"],
                 "u2netp: lightweight general purpose": ["u2netp.onnx"],
                 "u2net_human_seg: human segmentation": ["u2net_human_seg.onnx"],
-                "u2net_cloth_seg: cloths": ["u2net_cloth_seg.onnx"],
+                "u2net_cloth_seg: cloths Parsing": ["u2net_cloth_seg.onnx"],
                 "silueta: very small u2net": ["silueta.onnx"],
                 "isnet-general-use: general purpose": ["isnet-general-use.onnx"],
                 "isnet-anime: anime illustrations": ["isnet-anime.onnx"],
@@ -49,13 +36,3 @@ class rembg(CustomNodeHelper):
                 )
             else:
                 weights_to_download.extend([f"{model}.onnx"])
-
-    @staticmethod
-    def weights_map(base_url):
-        return {
-            model: {
-                "url": f"{base_url}/rembg/{model}.tar",
-                "dest": f"{BASE_PATH}{model}",
-            }
-            for model in MODELS
-        }

--- a/custom_node_helpers/rembg.py
+++ b/custom_node_helpers/rembg.py
@@ -1,6 +1,5 @@
 from custom_node_helper import CustomNodeHelper
 
-BASE_PATH = "/root/.u2net/"
 
 class rembg(CustomNodeHelper):
     @staticmethod

--- a/custom_node_helpers/rembg.py
+++ b/custom_node_helpers/rembg.py
@@ -1,0 +1,61 @@
+from custom_node_helper import CustomNodeHelper
+from node import Node
+
+BASE_PATH = "/root/.u2net/"
+MODELS = [
+    "isnet-anime.onnx",
+    "isnet-general-use.onnx",
+    "silueta.onnx",
+    "u2net.onnx",
+    "u2net_cloth_seg.onnx",
+    "u2net_human_seg.onnx",
+    "u2netp.onnx",
+    "vit_b-decoder-quant.onnx",
+    "vit_b-encoder-quant.onnx",
+]
+
+
+class rembg(CustomNodeHelper):
+    @staticmethod
+    def add_weights(weights_to_download, node):
+        # RemBGSession+ is in ComfyUI_essentials
+        if Node.is_type(node, "RemBGSession+"):
+            model = Node.value(node, "model")
+            model_weights = {
+                "u2net: general purpose": ["u2net.onnx"],
+                "u2netp: lightweight general purpose": ["u2netp.onnx"],
+                "u2net_human_seg: human segmentation": ["u2net_human_seg.onnx"],
+                "u2net_cloth_seg: cloths": ["u2net_cloth_seg.onnx"],
+                "silueta: very small u2net": ["silueta.onnx"],
+                "isnet-general-use: general purpose": ["isnet-general-use.onnx"],
+                "isnet-anime: anime illustrations": ["isnet-anime.onnx"],
+                "sam: general purpose": [
+                    "vit_b-decoder-quant.onnx",
+                    "vit_b-encoder-quant.onnx",
+                ],
+            }
+            if model in model_weights:
+                weights_to_download.extend(model_weights[model])
+
+        # Image Rembg (Remove Background) is in WAS nodes
+        elif Node.is_type(node, "Image Rembg (Remove Background)"):
+            model = Node.value(node, "model")
+            if model == "sam":
+                weights_to_download.extend(
+                    [
+                        "vit_b-decoder-quant.onnx",
+                        "vit_b-encoder-quant.onnx",
+                    ]
+                )
+            else:
+                weights_to_download.extend([f"{model}.onnx"])
+
+    @staticmethod
+    def weights_map(base_url):
+        return {
+            model: {
+                "url": f"{base_url}/rembg/{model}.tar",
+                "dest": f"{BASE_PATH}{model}",
+            }
+            for model in MODELS
+        }

--- a/custom_nodes.json
+++ b/custom_nodes.json
@@ -48,9 +48,8 @@
     "commit": "cd6cadd"
   },
   {
-    "repo": "https://github.com/fofr/ComfyUI_tinyterraNodes",
-    "comments": "Forked to remove rembg nodes which were causing a slow startup time. https://github.com/TinyTerra/ComfyUI_tinyterraNodes/issues/104",
-    "commit": "e980b9c"
+    "repo": "https://github.com/TinyTerra/ComfyUI_tinyterraNodes",
+    "commit": "8d8bb56"
   },
   {
     "repo": "https://github.com/ssitu/ComfyUI_UltimateSDUpscale",

--- a/custom_nodes.json
+++ b/custom_nodes.json
@@ -48,8 +48,9 @@
     "commit": "cd6cadd"
   },
   {
-    "repo": "https://github.com/TinyTerra/ComfyUI_tinyterraNodes",
-    "commit": "eda8a09"
+    "repo": "https://github.com/fofr/ComfyUI_tinyterraNodes",
+    "comments": "Forked to remove rembg nodes which were causing a slow startup time. https://github.com/TinyTerra/ComfyUI_tinyterraNodes/issues/104",
+    "commit": "e980b9c"
   },
   {
     "repo": "https://github.com/ssitu/ComfyUI_UltimateSDUpscale",

--- a/examples/api_workflows/all_preprocessors.json
+++ b/examples/api_workflows/all_preprocessors.json
@@ -16,7 +16,7 @@
   },
   "2": {
     "inputs": {
-      "image": "example.png",
+      "image": "https://replicate.delivery/pbxt/iFAVZOMyKxJmDhOiyYTLFBBrG9M1TTlJl9Ye2KprPu2e6ovSA/ComfyUI_00001_.webp",
       "upload": "image"
     },
     "class_type": "LoadImage",
@@ -206,7 +206,7 @@
   },
   "21": {
     "inputs": {
-      "image": "hands.png",
+      "image": "https://replicate.delivery/pbxt/KqQAtDFPsCYgBjuv0Pviq87qq7oYNiHtZvjnvVdsqmuqi6w3/IMG_0406.jpeg",
       "upload": "image"
     },
     "class_type": "LoadImage",
@@ -804,7 +804,7 @@
   },
   "66": {
     "inputs": {
-      "image": "man.png",
+      "image": "https://replicate.delivery/pbxt/KqN2iJQ0LZNjDm3WWl2XCJ01qwxcLLMWVKoUiI1tCm4IUhaJ/0_3.webp",
       "upload": "image"
     },
     "class_type": "LoadImage",
@@ -986,7 +986,7 @@
   },
   "81": {
     "inputs": {
-      "image": "cat.png",
+      "image": "https://replicate.delivery/pbxt/iFAVZOMyKxJmDhOiyYTLFBBrG9M1TTlJl9Ye2KprPu2e6ovSA/ComfyUI_00001_.webp",
       "upload": "image"
     },
     "class_type": "LoadImage",

--- a/examples/api_workflows/instantid_default_api.json
+++ b/examples/api_workflows/instantid_default_api.json
@@ -67,7 +67,7 @@
   },
   "11": {
     "inputs": {
-      "instantid_file": "instantid-ip-adapter.bin"
+      "instantid_file": "ipadapter.bin"
     },
     "class_type": "InstantIDModelLoader",
     "_meta": {
@@ -76,7 +76,7 @@
   },
   "13": {
     "inputs": {
-      "image": "unnamed-2.png",
+      "image": "https://replicate.delivery/pbxt/Kr1IxUhFxQij1VZgKpAmkjtbKaZu93KoFymbgOOOEjNYQPWv/0_3.webp",
       "upload": "image"
     },
     "class_type": "LoadImage",
@@ -98,7 +98,7 @@
   },
   "16": {
     "inputs": {
-      "control_net_name": "instantid-controlnet.safetensors"
+      "control_net_name": "instantid/diffusion_pytorch_model.safetensors"
     },
     "class_type": "ControlNetLoader",
     "_meta": {

--- a/examples/api_workflows/rembg_api.json
+++ b/examples/api_workflows/rembg_api.json
@@ -1,0 +1,85 @@
+{
+  "1": {
+    "inputs": {
+      "model": "silueta: very small u2net",
+      "providers": "CUDA"
+    },
+    "class_type": "RemBGSession+",
+    "_meta": {
+      "title": "🔧 RemBG Session"
+    }
+  },
+  "2": {
+    "inputs": {
+      "transparency": true,
+      "model": "u2net",
+      "post_processing": false,
+      "only_mask": false,
+      "alpha_matting": false,
+      "alpha_matting_foreground_threshold": 240,
+      "alpha_matting_background_threshold": 10,
+      "alpha_matting_erode_size": 10,
+      "background_color": "none",
+      "images": [
+        "4",
+        0
+      ]
+    },
+    "class_type": "Image Rembg (Remove Background)",
+    "_meta": {
+      "title": "Image Rembg (Remove Background)"
+    }
+  },
+  "4": {
+    "inputs": {
+      "image": "https://replicate.delivery/pbxt/Kr1IxUhFxQij1VZgKpAmkjtbKaZu93KoFymbgOOOEjNYQPWv/0_3.webp",
+      "upload": "image"
+    },
+    "class_type": "LoadImage",
+    "_meta": {
+      "title": "Load Image"
+    }
+  },
+  "5": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "2",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  },
+  "6": {
+    "inputs": {
+      "rembg_session": [
+        "1",
+        0
+      ],
+      "image": [
+        "4",
+        0
+      ]
+    },
+    "class_type": "ImageRemoveBackground+",
+    "_meta": {
+      "title": "🔧 Image Remove Background"
+    }
+  },
+  "7": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "6",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  }
+}

--- a/examples/ui_workflows/rembg_ui.json
+++ b/examples/ui_workflows/rembg_ui.json
@@ -1,0 +1,271 @@
+{
+  "last_node_id": 7,
+  "last_link_id": 5,
+  "nodes": [
+    {
+      "id": 2,
+      "type": "Image Rembg (Remove Background)",
+      "pos": [
+        849,
+        528
+      ],
+      "size": {
+        "0": 315,
+        "1": 250
+      },
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": [
+            2
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "Image Rembg (Remove Background)"
+      },
+      "widgets_values": [
+        true,
+        "u2net",
+        false,
+        false,
+        false,
+        240,
+        10,
+        10,
+        "none"
+      ]
+    },
+    {
+      "id": 5,
+      "type": "SaveImage",
+      "pos": [
+        1264,
+        534
+      ],
+      "size": {
+        "0": 315,
+        "1": 58
+      },
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 2
+        }
+      ],
+      "properties": {},
+      "widgets_values": [
+        "ComfyUI"
+      ]
+    },
+    {
+      "id": 6,
+      "type": "ImageRemoveBackground+",
+      "pos": [
+        976.43798828125,
+        920.6688232421875
+      ],
+      "size": {
+        "0": 241.79998779296875,
+        "1": 46
+      },
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "rembg_session",
+          "type": "REMBG_SESSION",
+          "link": 3
+        },
+        {
+          "name": "image",
+          "type": "IMAGE",
+          "link": 4
+        }
+      ],
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            5
+          ],
+          "shape": 3,
+          "slot_index": 0
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "ImageRemoveBackground+"
+      }
+    },
+    {
+      "id": 7,
+      "type": "SaveImage",
+      "pos": [
+        1337,
+        918
+      ],
+      "size": {
+        "0": 315,
+        "1": 58
+      },
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 5
+        }
+      ],
+      "properties": {},
+      "widgets_values": [
+        "ComfyUI"
+      ]
+    },
+    {
+      "id": 4,
+      "type": "LoadImage",
+      "pos": [
+        477,
+        519
+      ],
+      "size": [
+        315,
+        314
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "outputs": [
+        {
+          "name": "IMAGE",
+          "type": "IMAGE",
+          "links": [
+            1,
+            4
+          ],
+          "shape": 3,
+          "slot_index": 0
+        },
+        {
+          "name": "MASK",
+          "type": "MASK",
+          "links": null,
+          "shape": 3
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "LoadImage"
+      },
+      "widgets_values": [
+        "0_3.webp",
+        "image"
+      ]
+    },
+    {
+      "id": 1,
+      "type": "RemBGSession+",
+      "pos": [
+        582,
+        916
+      ],
+      "size": {
+        "0": 315,
+        "1": 82
+      },
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "outputs": [
+        {
+          "name": "REMBG_SESSION",
+          "type": "REMBG_SESSION",
+          "links": [
+            3
+          ],
+          "shape": 3,
+          "slot_index": 0
+        }
+      ],
+      "properties": {
+        "Node name for S&R": "RemBGSession+"
+      },
+      "widgets_values": [
+        "silueta: very small u2net",
+        "CUDA"
+      ]
+    }
+  ],
+  "links": [
+    [
+      1,
+      4,
+      0,
+      2,
+      0,
+      "IMAGE"
+    ],
+    [
+      2,
+      2,
+      0,
+      5,
+      0,
+      "IMAGE"
+    ],
+    [
+      3,
+      1,
+      0,
+      6,
+      0,
+      "REMBG_SESSION"
+    ],
+    [
+      4,
+      4,
+      0,
+      6,
+      1,
+      "IMAGE"
+    ],
+    [
+      5,
+      6,
+      0,
+      7,
+      0,
+      "IMAGE"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {},
+  "version": 0.4
+}

--- a/node.py
+++ b/node.py
@@ -1,0 +1,16 @@
+class Node:
+    @staticmethod
+    def is_type(title, node):
+        return "class_type" in node and node["class_type"] == title
+
+    @staticmethod
+    def is_type_in(node, types):
+        return "class_type" in node and node["class_type"] in types
+
+    @staticmethod
+    def has_key(node, key):
+        return key in node["inputs"]
+
+    @staticmethod
+    def value(node, key, default_value=None):
+        return node["inputs"][key] if key in node["inputs"] else default_value

--- a/node.py
+++ b/node.py
@@ -1,16 +1,25 @@
 class Node:
-    @staticmethod
-    def is_type(title, node):
-        return "class_type" in node and node["class_type"] == title
+    def __init__(self, node):
+        self.node = node
 
-    @staticmethod
-    def is_type_in(node, types):
-        return "class_type" in node and node["class_type"] in types
+    def type(self):
+        return self.node["class_type"]
 
-    @staticmethod
-    def has_key(node, key):
-        return key in node["inputs"]
+    def is_type(self, type):
+        return "class_type" in self.node and self.node["class_type"] == type
 
-    @staticmethod
-    def value(node, key, default_value=None):
-        return node["inputs"][key] if key in node["inputs"] else default_value
+    def is_type_in(self, types):
+        return "class_type" in self.node and self.node["class_type"] in types
+
+    def has_input(self, key):
+        return key in self.node["inputs"]
+
+    def input(self, key, default_value=None):
+        return self.node["inputs"][key] if key in self.node["inputs"] else default_value
+
+    def set_input(self, key, value):
+        self.node["inputs"][key] = value
+
+    def raise_if_unsupported(self, unsupported_nodes={}):
+        if self.is_type_in(unsupported_nodes):
+            raise ValueError(f"{self.type()} node is not supported: {unsupported_nodes[self.type()]}")

--- a/supported_weights.md
+++ b/supported_weights.md
@@ -450,6 +450,18 @@
 
 - models--CIDAS--clipseg-rd64-refined
 
+## REMBG (Remove background)
+
+- isnet-anime.onnx
+- isnet-general-use.onnx
+- silueta.onnx
+- u2net.onnx
+- u2net_cloth_seg.onnx
+- u2net_human_seg.onnx
+- u2netp.onnx
+- vit_b-decoder-quant.onnx
+- vit_b-encoder-quant.onnx
+
 ## AnimateDiff
 
 - mm_sd_v14.ckpt

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1,0 +1,82 @@
+import base64
+import sys
+import requests
+import glob
+import time
+
+
+def check_if_cog_server_running():
+    """
+    To set up, first run a local cog server using:
+       cog run -p 5000 python -m cog.server.http
+    Then, in a separate terminal, generate samples
+       python samples.py
+    """
+    try:
+        response = requests.get("http://localhost:5000")
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        print("cog server is not running. Start the server before running the tests.")
+        print("cog run -p 5000 python -m cog.server.http")
+        sys.exit(1)
+
+
+def load_example_workflow_json(filename):
+    with open(filename, "r") as file:
+        return file.read()
+
+
+def run(output_fn, **kwargs):
+    if glob.glob(f"{output_fn.rsplit('.', 1)[0]}*"):
+        print("Already ran", output_fn)
+        return
+
+    prediction_start = time.time()
+    print("Running prediction", output_fn)
+    url = "http://localhost:5000/predictions"
+    response = requests.post(url, json={"input": kwargs})
+    print(f"Prediction took: {time.time() - prediction_start:.2f}s")
+    data = response.json()
+    try:
+        for i, datauri in enumerate(data["output"]):
+            base64_encoded_data = datauri.split(",")[1]
+            decoded_data = base64.b64decode(base64_encoded_data)
+            filename = f"{output_fn.rsplit('.', 1)[0]}_{i}.{output_fn.rsplit('.', 1)[1]}"
+            with open(
+                filename, "wb"
+            ) as f:
+                f.write(decoded_data)
+            print("Wrote", filename)
+    except Exception as e:
+        print("Error!", str(e))
+        print("input:", kwargs)
+        print(data["logs"])
+        sys.exit(1)
+
+
+def main():
+    BASE_PATH = "examples/api_workflows"
+    examples_to_test = [
+        "rembg_api.json",
+        "segment_anything_api.json",
+        "layer_diffuse_api.json",
+        "was_clipseg_basic_api.json",
+        "comfyui_essentials_all_workflows.json",
+        "bria_rmbg_api.json",
+        "sd15_img2img.json",
+        "sd15_txt2img.json",
+        "sd15_inpainting.json",
+        "all_preprocessors.json",
+    ]
+
+    for example in examples_to_test:
+        run(
+            f"sample_{example.rsplit('.', 1)[0]}.webp",
+            return_temp_files=True,
+            workflow_json=load_example_workflow_json(f"{BASE_PATH}/{example}"),
+        )
+
+
+if __name__ == "__main__":
+    check_if_cog_server_running()
+    main()

--- a/weights.json
+++ b/weights.json
@@ -433,5 +433,16 @@
   ],
   "CLIPSEG": [
     "models--CIDAS--clipseg-rd64-refined"
+  ],
+  "REMBG": [
+    "isnet-anime.onnx",
+    "isnet-general-use.onnx",
+    "silueta.onnx",
+    "u2net.onnx",
+    "u2net_cloth_seg.onnx",
+    "u2net_human_seg.onnx",
+    "u2netp.onnx",
+    "vit_b-decoder-quant.onnx",
+    "vit_b-encoder-quant.onnx"
   ]
 }

--- a/weights_manifest.py
+++ b/weights_manifest.py
@@ -134,6 +134,7 @@ class WeightsManifest:
             "Face detection models": self.get_weights_by_type("FACEDETECTION"),
             "LayerDiffusion": self.get_weights_by_type("LAYER_MODEL"),
             "CLIP Segmentation": self.get_weights_by_type("CLIPSEG"),
+            "REMBG (Remove background)": self.get_weights_by_type("REMBG"),
             "AnimateDiff": helpers.ComfyUI_AnimateDiff_Evolved.models(),
             "AnimateDiff LORAs": helpers.ComfyUI_AnimateDiff_Evolved.loras(),
             "Frame Interpolation": helpers.ComfyUI_Frame_Interpolation.models(),


### PR DESCRIPTION
Allow using rembg nodes in ComfyUI_Essentials and WAS nodes.
Adds all the necessary weights

- Updates tinyterraNodes to get fix so that rembg will work
- Puts weights in /models/rembg for nodes to use
- Introduce a Node class for convenience methods when interacting with a node
- Apply that Node class when loading weights/checking unsupported nodes
- Added a testing script
- Fixed examples to run with testing script
- Include rembg examples