### PR TITLE
Add `Cgem156-ComfyUI` Pack

### DIFF
--- a/custom_nodes.json
+++ b/custom_nodes.json
@@ -130,5 +130,9 @@
   {
     "repo": "https://github.com/rgthree/rgthree-comfy",
     "commit": "23fddb8"
+  },
+  {
+    "repo": "https://github.com/laksjdjf/cgem156-ComfyUI",
+    "commit": "af194b2"
   }
 ]


### PR DESCRIPTION
I have added support for the `Cgem156-ComfyUI` Custom Nodes Pack, primarily to enable Attention Couple Support. This feature is incredibly useful for specifying prompts for different regions of an image while maintaining its overall integrity. It also differs from other nodes that use Latent Couple. 

It doesn't require any custom node helper functions and it doesn't depend on any specific weights. Also, all dependencies are already in cog.yaml, so I didn't touch it.