### PR TITLE
Fix name of controlnet model directory

### DIFF
--- a/train.py
+++ b/train.py
@@ -227,7 +227,7 @@ def train(
         "LORAS": loras.splitlines() if loras else [],
         "UPSCALE_MODELS": upscale_models.splitlines() if upscale_models else [],
         "EMBEDDINGS": embedding_models.splitlines() if embedding_models else [],
-        "CONTROLNETS": controlnets.splitlines() if controlnets else [],
+        "CONTROLNET": controlnets.splitlines() if controlnets else [],
         "ANIMATEDIFF_MODELS": animatediff_models.splitlines()
         if animatediff_models
         else [],


### PR DESCRIPTION
**Issue description:**

When training ComfyUI cogs with new controlnet models, all files are stored in `ComfyUI/models/controlnets` directory but comfyUI expects files in directory `ComfyUI/models/controlnet`

**Changes**
Change list of urls hash key name to `CONTROLNET` .