### PR TITLE
Fix ComfyUI broken pipe errors seen in v0.9.13 of cog and upwards

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -18,7 +18,7 @@ INPUT_DIR = "/tmp/inputs"
 COMFYUI_TEMP_OUTPUT_DIR = "ComfyUI/temp"
 ALL_DIRECTORIES = [OUTPUT_DIR, INPUT_DIR, COMFYUI_TEMP_OUTPUT_DIR]
 
-with open("examples/api_workflows/xlabs_flux_controlnet_api.json", "r") as file:
+with open("examples/api_workflows/sd15_txt2img.json", "r") as file:
     EXAMPLE_WORKFLOW_JSON = file.read()
 
 


### PR DESCRIPTION
When running a ComfyUI workflow on cog v0.9.13 and upwards, the workflow would seem to randomly just stop and there would be no output. On adding error logging a broken pipe error was reported.

The error would always stop at the point where it would attempt to print or log something (like tqdm or otherwise).

ComfyUI is running in a subprocess (and the server it runs has some async methods), and the model gets updates from webhooks, which it prints. But at the same time Comfy is printing it's own outputs (like inference steps) which are also useful.

It seems to be related to this change in cog:
https://github.com/replicate/cog/pull/1802

The fix here is to capture all stdout/stderr from the subprocess and log it separately.