### PR TITLE
fix recursion bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ manifest.txt
 updated_weights.json
 downloaded_user_models/
 .cog
+
+.idea

--- a/comfyui.py
+++ b/comfyui.py
@@ -324,7 +324,7 @@ class ComfyUI:
                     files.append(Path(path))
                 elif os.path.isdir(path):
                     print(f"{prefix}{f}/")
-                    files.extend(self.get_files(path, prefix=f"{prefix}{f}/"))
+                    self.get_files(path, prefix=f"{prefix}{f}/")
 
         if file_extensions:
             files = [f for f in files if f.name.split(".")[-1] in file_extensions]


### PR DESCRIPTION
In general, the output directory only contains files. However, if there are folders, the recursion will repeatedly retrieve all the files within those folders.