### PR TITLE
Add ComfyUI-GlifNodes for loading loras from a URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2025-01-14
+
+- [Add ComfyUI-GlifNodes](https://github.com/glifxyz/ComfyUI-GlifNodes)
+  - Allows downloading safetensors lora weights from URLs using the `LoraLoaderFromURL` node, see [examples/api_workflows/glif_custom_lora_flux_civitai.json](examples/api_workflows/glif_custom_lora_flux_civitai.json)
+
 ## 2025-01-06
 
 - [Update ComfyUI to latest](https://github.com/comfyanonymous/ComfyUI/compare/c441048...916d1e1)

--- a/comfyui.py
+++ b/comfyui.py
@@ -135,7 +135,7 @@ class ComfyUI:
         print("Checking inputs")
         seen_inputs = set()
         for node in workflow.values():
-            # Skip URLs in LoraLoaderFromURL nodes
+            # Skip URLs in LoraLoader nodes
             if node.get("class_type") in ["LoraLoaderFromURL", "LoraLoader"]:
                 continue
 

--- a/comfyui.py
+++ b/comfyui.py
@@ -95,6 +95,10 @@ class ComfyUI:
         weights_filetypes = self.weights_downloader.supported_filetypes
 
         for node in workflow.values():
+            # Skip HFHubLoraLoader and LoraLoaderFromURL nodes since they handle their own weights
+            if node.get("class_type") in ["HFHubLoraLoader", "LoraLoaderFromURL"]:
+                continue
+
             self.apply_helper_methods("add_weights", weights_to_download, Node(node))
 
             for input in node["inputs"].values():

--- a/comfyui.py
+++ b/comfyui.py
@@ -129,6 +129,10 @@ class ComfyUI:
         print("Checking inputs")
         seen_inputs = set()
         for node in workflow.values():
+            # Skip URLs in LoraLoaderFromURL nodes
+            if node.get("class_type") == "LoraLoaderFromURL":
+                continue
+
             if "inputs" in node:
                 for input_key, input_value in node["inputs"].items():
                     if isinstance(input_value, str) and input_value not in seen_inputs:

--- a/custom_nodes.json
+++ b/custom_nodes.json
@@ -222,5 +222,9 @@
   {
     "repo": "https://github.com/kijai/ComfyUI-segment-anything-2",
     "commit": "059815e"
+  },
+  {
+    "repo": "https://github.com/glifxyz/ComfyUI-GlifNodes",
+    "commit": "b86352c"
   }
 ]

--- a/examples/api_workflows/glif_custom_lora_flux_civitai.json
+++ b/examples/api_workflows/glif_custom_lora_flux_civitai.json
@@ -1,0 +1,125 @@
+{
+  "1": {
+    "inputs": {
+      "ckpt_name": "flux1-dev-fp8.safetensors"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "Load Checkpoint"
+    }
+  },
+  "2": {
+    "inputs": {
+      "url": "https://civitai.com/api/download/models/1163532?type=Model&format=SafeTensor",
+      "strength_model": 1,
+      "strength_clip": 1,
+      "model": [
+        "1",
+        0
+      ],
+      "clip": [
+        "1",
+        1
+      ]
+    },
+    "class_type": "LoraLoaderFromURL",
+    "_meta": {
+      "title": "Load Lora from URL"
+    }
+  },
+  "3": {
+    "inputs": {
+      "seed": 19333938802977,
+      "steps": 20,
+      "cfg": 1,
+      "sampler_name": "euler",
+      "scheduler": "normal",
+      "denoise": 1,
+      "model": [
+        "2",
+        0
+      ],
+      "positive": [
+        "4",
+        0
+      ],
+      "negative": [
+        "5",
+        0
+      ],
+      "latent_image": [
+        "6",
+        0
+      ]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "KSampler"
+    }
+  },
+  "4": {
+    "inputs": {
+      "text": " HWRIT handwriting saying \"Hello, this is a handwriting lora\", messy style, blue ink on paper",
+      "clip": [
+        "2",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Prompt)"
+    }
+  },
+  "5": {
+    "inputs": {
+      "conditioning": [
+        "4",
+        0
+      ]
+    },
+    "class_type": "ConditioningZeroOut",
+    "_meta": {
+      "title": "ConditioningZeroOut"
+    }
+  },
+  "6": {
+    "inputs": {
+      "width": 1024,
+      "height": 1024,
+      "batch_size": 1
+    },
+    "class_type": "EmptyLatentImage",
+    "_meta": {
+      "title": "Empty Latent Image"
+    }
+  },
+  "7": {
+    "inputs": {
+      "samples": [
+        "3",
+        0
+      ],
+      "vae": [
+        "1",
+        2
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "8": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "7",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  }
+}

--- a/examples/api_workflows/glif_custom_lora_flux_hf.json
+++ b/examples/api_workflows/glif_custom_lora_flux_hf.json
@@ -1,0 +1,125 @@
+{
+  "1": {
+    "inputs": {
+      "ckpt_name": "flux1-dev-fp8.safetensors"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "Load Checkpoint"
+    }
+  },
+  "2": {
+    "inputs": {
+      "lora_name": "https://huggingface.co/fofr/flux-condensation/blob/main/lora.safetensors",
+      "strength_model": 1,
+      "strength_clip": 1,
+      "model": [
+        "1",
+        0
+      ],
+      "clip": [
+        "1",
+        1
+      ]
+    },
+    "class_type": "LoraLoader",
+    "_meta": {
+      "title": "Load LoRA"
+    }
+  },
+  "3": {
+    "inputs": {
+      "seed": 19333938802977,
+      "steps": 20,
+      "cfg": 1,
+      "sampler_name": "euler",
+      "scheduler": "normal",
+      "denoise": 1,
+      "model": [
+        "2",
+        0
+      ],
+      "positive": [
+        "4",
+        0
+      ],
+      "negative": [
+        "5",
+        0
+      ],
+      "latent_image": [
+        "6",
+        0
+      ]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "KSampler"
+    }
+  },
+  "4": {
+    "inputs": {
+      "text": "the word \"hello\" written in CONDENSATION on the window",
+      "clip": [
+        "2",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Prompt)"
+    }
+  },
+  "5": {
+    "inputs": {
+      "conditioning": [
+        "4",
+        0
+      ]
+    },
+    "class_type": "ConditioningZeroOut",
+    "_meta": {
+      "title": "ConditioningZeroOut"
+    }
+  },
+  "6": {
+    "inputs": {
+      "width": 1024,
+      "height": 1024,
+      "batch_size": 1
+    },
+    "class_type": "EmptyLatentImage",
+    "_meta": {
+      "title": "Empty Latent Image"
+    }
+  },
+  "7": {
+    "inputs": {
+      "samples": [
+        "3",
+        0
+      ],
+      "vae": [
+        "1",
+        2
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "8": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "7",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  }
+}

--- a/examples/api_workflows/glif_custom_lora_flux_hf_load.json
+++ b/examples/api_workflows/glif_custom_lora_flux_hf_load.json
@@ -1,0 +1,127 @@
+{
+  "1": {
+    "inputs": {
+      "ckpt_name": "flux1-dev-fp8.safetensors"
+    },
+    "class_type": "CheckpointLoaderSimple",
+    "_meta": {
+      "title": "Load Checkpoint"
+    }
+  },
+  "3": {
+    "inputs": {
+      "seed": 590815517412234,
+      "steps": 20,
+      "cfg": 1,
+      "sampler_name": "euler",
+      "scheduler": "normal",
+      "denoise": 1,
+      "model": [
+        "9",
+        0
+      ],
+      "positive": [
+        "4",
+        0
+      ],
+      "negative": [
+        "5",
+        0
+      ],
+      "latent_image": [
+        "6",
+        0
+      ]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "KSampler"
+    }
+  },
+  "4": {
+    "inputs": {
+      "text": " HWRIT handwriting saying \"Hello, this is a handwriting lora\", messy style, blue ink on paper",
+      "clip": [
+        "9",
+        1
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Prompt)"
+    }
+  },
+  "5": {
+    "inputs": {
+      "conditioning": [
+        "4",
+        0
+      ]
+    },
+    "class_type": "ConditioningZeroOut",
+    "_meta": {
+      "title": "ConditioningZeroOut"
+    }
+  },
+  "6": {
+    "inputs": {
+      "width": 1024,
+      "height": 1024,
+      "batch_size": 1
+    },
+    "class_type": "EmptyLatentImage",
+    "_meta": {
+      "title": "Empty Latent Image"
+    }
+  },
+  "7": {
+    "inputs": {
+      "samples": [
+        "3",
+        0
+      ],
+      "vae": [
+        "1",
+        2
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "8": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "7",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  },
+  "9": {
+    "inputs": {
+      "repo_id": "fofr/flux-handwriting",
+      "subfolder": "",
+      "filename": "lora.safetensors",
+      "strength_model": 1,
+      "strength_clip": 1,
+      "model": [
+        "1",
+        0
+      ],
+      "clip": [
+        "1",
+        1
+      ]
+    },
+    "class_type": "HFHubLoraLoader",
+    "_meta": {
+      "title": "Load HF Lora"
+    }
+  }
+}


### PR DESCRIPTION
[Add ComfyUI-GlifNodes](https://github.com/glifxyz/ComfyUI-GlifNodes)
 
Allows downloading safetensors lora weights from URLs using the `LoraLoaderFromURL` node, see `examples/api_workflows/glif_custom_lora_flux_civitai.json`

If a lora url is given as a lora_name in the standard LoraLoader node, then this will automatically switch to use LoraLoaderFromURL (which has the same API) so that the lora _just works_.

Both of these will work:

## Using LoraLoaderFromURL

```
"2": {
    "inputs": {
      "url": "https://civitai.com/api/download/models/1163532?type=Model&format=SafeTensor",
      "strength_model": 1,
      "strength_clip": 1,
      "model": [
        "1",
        0
      ],
      "clip": [
        "1",
        1
      ]
    },
    "class_type": "LoraLoaderFromURL",
    "_meta": {
      "title": "Load Lora from URL"
    }
  },
```

## Using LoraLoader with a URL as the lora_name input

```
"2": {
    "inputs": {
      "lora_name": "https://huggingface.co/fofr/flux-condensation/blob/main/lora.safetensors",
      "strength_model": 1,
      "strength_clip": 1,
      "model": [
        "1",
        0
      ],
      "clip": [
        "1",
        1
      ]
    },
    "class_type": "LoraLoader",
    "_meta": {
      "title": "Load LoRA"
    }
  },
```