### PR TITLE
Add support for Hunyuan Image 2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## 2025-11-03
 
+Add support for HunyuanImage 2.1:
+
+- [hunyuanimage2.1_refiner_fp8_e4m3fn.safetensors (diffusion_models)](https://huggingface.co/Comfy-Org/HunyuanImage_2.1_ComfyUI/blob/main/split_files/diffusion_models/hunyuanimage2.1_refiner_fp8_e4m3fn.safetensors)
+- [hunyuanimage2.1_refiner_bf16.safetensors (diffusion_models)](https://huggingface.co/Comfy-Org/HunyuanImage_2.1_ComfyUI/blob/main/split_files/diffusion_models/hunyuanimage2.1_refiner_bf16.safetensors)
+- [hunyuanimage2.1_fp8_e4m3fn.safetensors (diffusion_models)](https://huggingface.co/Comfy-Org/HunyuanImage_2.1_ComfyUI/blob/main/split_files/diffusion_models/hunyuanimage2.1_fp8_e4m3fn.safetensors)
+- [hunyuanimage2.1_distilled_fp8_e4m3fn.safetensors (diffusion_models)](https://huggingface.co/Comfy-Org/HunyuanImage_2.1_ComfyUI/blob/main/split_files/diffusion_models/hunyuanimage2.1_distilled_fp8_e4m3fn.safetensors)
+- [hunyuanimage2.1_distilled_bf16.safetensors (diffusion_models)](https://huggingface.co/Comfy-Org/HunyuanImage_2.1_ComfyUI/blob/main/split_files/diffusion_models/hunyuanimage2.1_distilled_bf16.safetensors)
+- [hunyuanimage2.1_bf16.safetensors (diffusion_models)](https://huggingface.co/Comfy-Org/HunyuanImage_2.1_ComfyUI/blob/main/split_files/diffusion_models/hunyuanimage2.1_bf16.safetensors)
+- [hunyuan_image_refiner_vae_fp16.safetensors (vae)](https://huggingface.co/Comfy-Org/HunyuanImage_2.1_ComfyUI/blob/main/split_files/vae/hunyuan_image_refiner_vae_fp16.safetensors)
+- [hunyuan_image_2.1_vae_fp16.safetensors (vae)](https://huggingface.co/Comfy-Org/HunyuanImage_2.1_ComfyUI/blob/main/split_files/vae/hunyuan_image_2.1_vae_fp16.safetensors)
+- [qwen_2.5_vl_7b.safetensors (text_encoders)](https://huggingface.co/Comfy-Org/HunyuanImage_2.1_ComfyUI/blob/main/split_files/text_encoders/qwen_2.5_vl_7b.safetensors)
+- [byt5_small_glyphxl_fp16.safetensors (text_encoders)](https://huggingface.co/Comfy-Org/HunyuanImage_2.1_ComfyUI/blob/main/split_files/text_encoders/byt5_small_glyphxl_fp16.safetensors)
+
 Add support for Qwen-Image and Qwen-Image-Edit:
 
 - [qwen_image_vae.safetensors (vae)](https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/blob/main/split_files/vae/qwen_image_vae.safetensors)

--- a/examples/api_workflows/hunyuan_image_example_api.json
+++ b/examples/api_workflows/hunyuan_image_example_api.json
@@ -1,0 +1,129 @@
+{
+  "3": {
+    "inputs": {
+      "seed": 560947545375702,
+      "steps": 20,
+      "cfg": 3.5,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "denoise": 1,
+      "model": [
+        "13",
+        0
+      ],
+      "positive": [
+        "6",
+        0
+      ],
+      "negative": [
+        "7",
+        0
+      ],
+      "latent_image": [
+        "29",
+        0
+      ]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "KSampler"
+    }
+  },
+  "6": {
+    "inputs": {
+      "text": "cute anime girl with massive fennec ears and a big fluffy fox tail with long wavy blonde hair between eyes and large blue eyes blonde colored eyelashes chubby wearing oversized clothes summer uniform large black coat long blue maxi skirt muddy clothes happy sitting on the side of the road in a run down dark gritty cyberpunk city with neon and a crumbling skyscraper in the rain at night while dipping her feet in a river of water she is holding a sign that says \"ComfyUI is the best\" and another one that says \"The Future is Comfy\"",
+      "clip": [
+        "26",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Prompt)"
+    }
+  },
+  "7": {
+    "inputs": {
+      "text": "low quality, bad anatomy, extra digits, missing digits, extra limbs, missing limbs",
+      "clip": [
+        "26",
+        0
+      ]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Prompt)"
+    }
+  },
+  "8": {
+    "inputs": {
+      "samples": [
+        "3",
+        0
+      ],
+      "vae": [
+        "15",
+        0
+      ]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "13": {
+    "inputs": {
+      "unet_name": "hunyuanimage2.1_bf16.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {
+      "title": "Load Diffusion Model"
+    }
+  },
+  "15": {
+    "inputs": {
+      "vae_name": "hunyuan_image_2.1_vae_fp16.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load VAE"
+    }
+  },
+  "26": {
+    "inputs": {
+      "clip_name1": "qwen_2.5_vl_7b.safetensors",
+      "clip_name2": "byt5_small_glyphxl_fp16.safetensors",
+      "type": "hunyuan_image",
+      "device": "default"
+    },
+    "class_type": "DualCLIPLoader",
+    "_meta": {
+      "title": "DualCLIPLoader"
+    }
+  },
+  "29": {
+    "inputs": {
+      "width": 2048,
+      "height": 2048,
+      "batch_size": 1
+    },
+    "class_type": "EmptyHunyuanImageLatent",
+    "_meta": {
+      "title": "EmptyHunyuanImageLatent"
+    }
+  },
+  "41": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": [
+        "8",
+        0
+      ]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  }
+}

--- a/supported_weights.md
+++ b/supported_weights.md
@@ -174,6 +174,7 @@
 
 ## Text Encoders
 
+- byt5_small_glyphxl_fp16.safetensors
 - clip_g_hidream.safetensors
 - clip_l_hidream.safetensors
 - gemma_2_2b_fp16.safetensors
@@ -181,6 +182,7 @@
 - llava_llama3_fp16.safetensors
 - llava_llama3_fp8_scaled.safetensors
 - oldt5_xxl_fp8_e4m3fn_scaled.safetensors
+- qwen_2.5_vl_7b.safetensors
 - qwen_2.5_vl_7b_fp8_scaled.safetensors
 - umt5_xxl_fp16.safetensors
 - umt5_xxl_fp8_e4m3fn_scaled.safetensors
@@ -557,6 +559,8 @@
 
 - ae.safetensors (Also available as ae.sft)
 - cosmos_cv8x8x8_1.0.safetensors
+- hunyuan_image_2.1_vae_fp16.safetensors
+- hunyuan_image_refiner_vae_fp16.safetensors
 - hunyuan_video_vae_bf16.safetensors
 - mochi/mochi_preview_vae_bf16.safetensors
 - mochi_vae.safetensors
@@ -590,6 +594,12 @@
 - hidream_i1_full_fp8.safetensors
 - hunyuan_video_720_fp8_e4m3fn.safetensors
 - hunyuan_video_image_to_video_720p_bf16.safetensors (Also available as hunyuan_video_v2_replace_image_to_video_720p_bf16.safetensors)
+- hunyuanimage2.1_bf16.safetensors
+- hunyuanimage2.1_distilled_bf16.safetensors
+- hunyuanimage2.1_distilled_fp8_e4m3fn.safetensors
+- hunyuanimage2.1_fp8_e4m3fn.safetensors
+- hunyuanimage2.1_refiner_bf16.safetensors
+- hunyuanimage2.1_refiner_fp8_e4m3fn.safetensors
 - mochi/mochi_preview_dit_fp8_e4m3fn.safetensors
 - mochi_preview_bf16.safetensors
 - mochi_preview_fp8_scaled.safetensors

--- a/weights.json
+++ b/weights.json
@@ -172,6 +172,7 @@
     "RealESRGAN_x8.pth"
   ],
   "TEXT_ENCODERS": [
+    "byt5_small_glyphxl_fp16.safetensors",
     "clip_g_hidream.safetensors",
     "clip_l_hidream.safetensors",
     "gemma_2_2b_fp16.safetensors",
@@ -179,6 +180,7 @@
     "llava_llama3_fp16.safetensors",
     "llava_llama3_fp8_scaled.safetensors",
     "oldt5_xxl_fp8_e4m3fn_scaled.safetensors",
+    "qwen_2.5_vl_7b.safetensors",
     "qwen_2.5_vl_7b_fp8_scaled.safetensors",
     "umt5_xxl_fp16.safetensors",
     "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
@@ -551,6 +553,8 @@
   "VAE": [
     "ae.safetensors",
     "cosmos_cv8x8x8_1.0.safetensors",
+    "hunyuan_image_2.1_vae_fp16.safetensors",
+    "hunyuan_image_refiner_vae_fp16.safetensors",
     "hunyuan_video_vae_bf16.safetensors",
     "mochi/mochi_preview_vae_bf16.safetensors",
     "mochi_vae.safetensors",
@@ -609,6 +613,12 @@
     "hidream_i1_full_fp8.safetensors",
     "hunyuan_video_720_fp8_e4m3fn.safetensors",
     "hunyuan_video_image_to_video_720p_bf16.safetensors",
+    "hunyuanimage2.1_bf16.safetensors",
+    "hunyuanimage2.1_distilled_bf16.safetensors",
+    "hunyuanimage2.1_distilled_fp8_e4m3fn.safetensors",
+    "hunyuanimage2.1_fp8_e4m3fn.safetensors",
+    "hunyuanimage2.1_refiner_bf16.safetensors",
+    "hunyuanimage2.1_refiner_fp8_e4m3fn.safetensors",
     "mochi/mochi_preview_dit_fp8_e4m3fn.safetensors",
     "mochi_preview_bf16.safetensors",
     "mochi_preview_fp8_scaled.safetensors",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds HunyuanImage 2.1 support with new diffusion/vae/text-encoder weights, updates supported weight lists, and includes a sample API workflow; changelog also notes Qwen-Image(-Edit) support.
> 
> - **Weights**:
>   - **Diffusion models**: Add `hunyuanimage2.1_bf16.safetensors`, `hunyuanimage2.1_fp8_e4m3fn.safetensors`, `hunyuanimage2.1_distilled_bf16.safetensors`, `hunyuanimage2.1_distilled_fp8_e4m3fn.safetensors`, `hunyuanimage2.1_refiner_bf16.safetensors`, `hunyuanimage2.1_refiner_fp8_e4m3fn.safetensors` in `supported_weights.md` and `weights.json`.
>   - **VAE**: Add `hunyuan_image_2.1_vae_fp16.safetensors`, `hunyuan_image_refiner_vae_fp16.safetensors`.
>   - **Text encoders**: Add `qwen_2.5_vl_7b.safetensors`, `byt5_small_glyphxl_fp16.safetensors`.
> - **Examples**:
>   - Add `examples/api_workflows/hunyuan_image_example_api.json` demonstrating HunyuanImage 2.1 (`UNETLoader`, `DualCLIPLoader`, `EmptyHunyuanImageLatent`, `VAELoader`, `KSampler`).
> - **Docs**:
>   - Update `CHANGELOG.md` to announce HunyuanImage 2.1 and Qwen-Image / Qwen-Image-Edit support and list updated node refs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0dbfb11bb7d60234b195032afc2b62632a0bb397. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->