### PR TITLE
Add Flash VSR support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Add support for Qwen-Image and Qwen-Image-Edit:
 
 Updated nodes:
 
+- [Updated ComfyUI-RMBG](https://github.com/1038lab/ComfyUI-RMBG/compare/72bc6a5...b28ce10)
 - [Updated ComfyUI-WanVideoWrapper](https://github.com/kijai/ComfyUI-WanVideoWrapper/compare/a64f115...8ce6916)
 - [Updated ComfyUI-KJNodes](https://github.com/kijai/ComfyUI-KJNodes/compare/5dacc97...6c996e1)
 - [Updated ComfyUI_UltimateSDUpscale](https://github.com/ssitu/ComfyUI_UltimateSDUpscale/compare/871c7cb...c48d60d)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## 2025-11-03
 
+Add support for FlashVSR:
+
+- [Add ComfyUI-FlashVSR](https://github.com/1038lab/ComfyUI-FlashVSR) custom node
+- [Wan2_1_FlashVSR_TCDecoder_fp32.safetensors (flashvsr)](https://huggingface.co/1038lab/FlashVSR/blob/main/Wan2_1_FlashVSR_TCDecoder_fp32.safetensors)
+- [Wan2_1_FlashVSR_LQ_proj_model_bf16.safetensors (flashvsr)](https://huggingface.co/1038lab/FlashVSR/blob/main/Wan2_1_FlashVSR_LQ_proj_model_bf16.safetensors)
+- [Wan2_1-T2V-1_3B_FlashVSR_fp32.safetensors (flashvsr)](https://huggingface.co/1038lab/FlashVSR/blob/main/Wan2_1-T2V-1_3B_FlashVSR_fp32.safetensors)
+- [Wan2.1_VAE.safetensors (flashvsr)](https://huggingface.co/1038lab/FlashVSR/blob/main/Wan2.1_VAE.safetensors)
+- [Prompt.safetensors (flashvsr)](https://huggingface.co/1038lab/FlashVSR/blob/main/Prompt.safetensors)
+
 Add support for HunyuanImage 2.1:
 
 - [hunyuanimage2.1_refiner_fp8_e4m3fn.safetensors (diffusion_models)](https://huggingface.co/Comfy-Org/HunyuanImage_2.1_ComfyUI/blob/main/split_files/diffusion_models/hunyuanimage2.1_refiner_fp8_e4m3fn.safetensors)

--- a/custom_node_helpers/ComfyUI_FlashVSR.py
+++ b/custom_node_helpers/ComfyUI_FlashVSR.py
@@ -1,0 +1,20 @@
+from custom_node_helper import CustomNodeHelper
+
+
+FLASHVSR_WEIGHTS = [
+    "Wan2_1-T2V-1_3B_FlashVSR_fp32.safetensors",
+    "Wan2.1_VAE.safetensors",
+    "Wan2_1_FlashVSR_LQ_proj_model_bf16.safetensors",
+    "Wan2_1_FlashVSR_TCDecoder_fp32.safetensors",
+    "Prompt.safetensors",
+]
+
+
+class ComfyUI_FlashVSR(CustomNodeHelper):
+    @staticmethod
+    def add_weights(weights_to_download, node):
+        if node.is_type_in([
+            "AILab_FlashVSR",
+            "AILab_FlashVSR_Advanced",
+        ]):
+            weights_to_download.extend(FLASHVSR_WEIGHTS)

--- a/custom_nodes.json
+++ b/custom_nodes.json
@@ -275,5 +275,9 @@
   {
     "repo": "https://github.com/kijai/ComfyUI-WanVideoWrapper",
     "commit": "8ce6916"
+  },
+  {
+    "repo": "https://github.com/1038lab/ComfyUI-FlashVSR",
+    "commit": "545bdaf"
   }
 ]

--- a/custom_nodes.json
+++ b/custom_nodes.json
@@ -270,7 +270,7 @@
   },
   {
     "repo": "https://github.com/1038lab/ComfyUI-RMBG",
-    "commit": "72bc6a5"
+    "commit": "b28ce10"
   },
   {
     "repo": "https://github.com/kijai/ComfyUI-WanVideoWrapper",

--- a/custom_nodes.json
+++ b/custom_nodes.json
@@ -8,9 +8,8 @@
     "commit": "12f3564"
   },
   {
-    "repo": "https://github.com/fofr/ComfyUI-Impact-Pack",
-    "commit": "9ad8f85",
-    "notes": "Fork of https://github.com/ltdrdata/ComfyUI-Impact-Pack which prevents automatic installation of dependencies"
+    "repo": "https://github.com/ltdrdata/ComfyUI-Impact-Pack",
+    "commit": "2804f79"
   },
   {
     "repo": "https://github.com/ltdrdata/ComfyUI-Inspire-Pack",

--- a/examples/api_workflows/FlashVSR_api.json
+++ b/examples/api_workflows/FlashVSR_api.json
@@ -1,0 +1,139 @@
+{
+  "28": {
+    "inputs": {
+      "video_info": [
+        "31",
+        3
+      ]
+    },
+    "class_type": "VHS_VideoInfoSource",
+    "_meta": {
+      "title": "Video Info (Source) 🎥🅥🅗🅢"
+    }
+  },
+  "31": {
+    "inputs": {
+      "video": "https://replicate.delivery/xezq/lZfr3rskBEVLDCytear4lUo92fOpAcoblFWzk6e06WEnC3PTB/tmpny051d_c.mp4",
+      "force_rate": 0,
+      "custom_width": 0,
+      "custom_height": 0,
+      "frame_load_cap": 0,
+      "skip_first_frames": 0,
+      "select_every_nth": 1,
+      "format": "AnimateDiff"
+    },
+    "class_type": "VHS_LoadVideo",
+    "_meta": {
+      "title": "Load Video (Upload) 🎥🅥🅗🅢"
+    }
+  },
+  "33": {
+    "inputs": {
+      "model_version": "Full (Best Quality)",
+      "scale": 2,
+      "enable_tiling": true,
+      "tile_size": 256,
+      "tile_overlap": 24,
+      "speed_optimization": 2,
+      "quality_boost": 2,
+      "stability_level": 11,
+      "color_fix": true,
+      "vae_tiling": true,
+      "unload_model": false,
+      "sageattention": "enable",
+      "device": "auto",
+      "precision": "bf16",
+      "seed": 100,
+      "frames": [
+        "31",
+        0
+      ],
+      "audio": [
+        "31",
+        2
+      ]
+    },
+    "class_type": "AILab_FlashVSR_Advanced",
+    "_meta": {
+      "title": "FlashVSR ⚡ Advanced"
+    }
+  },
+  "39": {
+    "inputs": {
+      "frame_rate": [
+        "28",
+        0
+      ],
+      "loop_count": 0,
+      "filename_prefix": "FlashVSR",
+      "format": "video/h264-mp4",
+      "pix_fmt": "yuv420p",
+      "crf": 19,
+      "save_metadata": false,
+      "trim_to_audio": false,
+      "pingpong": false,
+      "save_output": false,
+      "images": [
+        "33",
+        0
+      ],
+      "audio": [
+        "33",
+        1
+      ]
+    },
+    "class_type": "VHS_VideoCombine",
+    "_meta": {
+      "title": "Video Combine 🎥🅥🅗🅢"
+    }
+  },
+  "40": {
+    "inputs": {
+      "frame_rate": [
+        "28",
+        0
+      ],
+      "loop_count": 0,
+      "filename_prefix": "FlashVSR",
+      "format": "video/h264-mp4",
+      "pix_fmt": "yuv420p",
+      "crf": 19,
+      "save_metadata": false,
+      "trim_to_audio": false,
+      "pingpong": false,
+      "save_output": false,
+      "images": [
+        "45",
+        0
+      ],
+      "audio": [
+        "45",
+        1
+      ]
+    },
+    "class_type": "VHS_VideoCombine",
+    "_meta": {
+      "title": "Video Combine 🎥🅥🅗🅢"
+    }
+  },
+  "45": {
+    "inputs": {
+      "preset": "Fast (2x Speed)",
+      "scale": 4,
+      "unload_model": false,
+      "seed": 100,
+      "frames": [
+        "31",
+        0
+      ],
+      "audio": [
+        "31",
+        2
+      ]
+    },
+    "class_type": "AILab_FlashVSR",
+    "_meta": {
+      "title": "FlashVSR ⚡"
+    }
+  }
+}

--- a/scripts/sort_weights.py
+++ b/scripts/sort_weights.py
@@ -51,6 +51,7 @@ def write_supported_weights():
         "Style models": weights_manifest.get_weights_by_type("STYLE_MODELS"),
         "DepthAnything": weights_manifest.get_weights_by_type("DEPTHANYTHING"),
         "FBCNN (Jpeg artifact removal)": weights_manifest.get_weights_by_type("FBCNN"),
+        "FlashVSR": weights_manifest.get_weights_by_type("FLASHVSR"),
         "Anyline": helpers.ComfyUI_Anyline.models(),
         "AnimateDiff": weights_manifest.get_weights_by_type("ANIMATEDIFF_MODELS"),
         "AnimateDiff LORAs": weights_manifest.get_weights_by_type(

--- a/supported_weights.md
+++ b/supported_weights.md
@@ -917,6 +917,14 @@
 
 - fbcnn_color.pth
 
+## FlashVSR
+
+- Prompt.safetensors
+- Wan2.1_VAE.safetensors
+- Wan2_1-T2V-1_3B_FlashVSR_fp32.safetensors
+- Wan2_1_FlashVSR_LQ_proj_model_bf16.safetensors
+- Wan2_1_FlashVSR_TCDecoder_fp32.safetensors
+
 ## Anyline
 
 - MTEED.pth

--- a/weights.json
+++ b/weights.json
@@ -963,5 +963,12 @@
   ],
   "FBCNN": [
     "fbcnn_color.pth"
+  ],
+  "FLASHVSR": [
+    "Prompt.safetensors",
+    "Wan2.1_VAE.safetensors",
+    "Wan2_1-T2V-1_3B_FlashVSR_fp32.safetensors",
+    "Wan2_1_FlashVSR_LQ_proj_model_bf16.safetensors",
+    "Wan2_1_FlashVSR_TCDecoder_fp32.safetensors"
   ]
 }

--- a/weights_manifest.py
+++ b/weights_manifest.py
@@ -103,6 +103,8 @@ class WeightsManifest:
         def generate_weights_map(keys, directory_name):
             if directory_name == "BIREFNET":
                 directory_name = "BiRefNet"
+            elif directory_name == "FLASHVSR":
+                directory_name = "FlashVSR"
             elif directory_name not in ["LLM", "FBCNN"]:
                 directory_name = directory_name.lower()
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds FlashVSR support with new custom node, weights category, and example API workflow; updates node list and docs.
> 
> - **FlashVSR support**
>   - Add `custom_node_helpers/ComfyUI_FlashVSR.py` to auto-download required FlashVSR weights for `AILab_FlashVSR*` nodes.
>   - Register FlashVSR weights (`FLASHVSR`) in `weights.json` and map to `models/FlashVSR` in `weights_manifest.py`.
>   - Include FlashVSR in `scripts/sort_weights.py` and `supported_weights.md`.
>   - Add example workflow `examples/api_workflows/FlashVSR_api.json`.
> - **Custom nodes**
>   - Add `ComfyUI-FlashVSR` to `custom_nodes.json`.
>   - Switch `ComfyUI-Impact-Pack` to original repo and update `ComfyUI-RMBG` commit.
> - **Docs/Changelog**
>   - Update `CHANGELOG.md` with FlashVSR models/links and node updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7af3d0252d7718b2faf5b1549ea5a200120e96d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->